### PR TITLE
fix: correct difficulty selector in score state

### DIFF
--- a/src/game/states/scores.ts
+++ b/src/game/states/scores.ts
@@ -72,7 +72,7 @@ export const Scores = {
         }
 
         sprite.setShadow(0, 0, 'rgba(0, 0, 0, 1)', 5);
-        this.difficulty = sprite.difficulty;
+        this.difficulty = sprite.data.difficulty;
         this.scores[this.difficulty].alpha = 1;
     },
     update: function() {


### PR DESCRIPTION
This fixes #25.

Selecting difficulty was broken, as the game tried to access a property of the sprite, that wasn't there anymore (.difficulty) and is now a nested property (.data.difficulty)