### PR TITLE
chore: add missing `@semantic-release/git` dependency to fix release

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "@babel/core": "^7.5.4",
         "@babel/preset-env": "^7.5.4",
         "@semantic-release/changelog": "^3.0.4",
+        "@semantic-release/git": "^7.0.16",
         "@semantic-release/github": "^5.4.2",
         "@storybook/addon-actions": "^5.1.9",
         "@storybook/addon-info": "^5.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,6 +1216,22 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
   integrity sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==
 
+"@semantic-release/git@^7.0.16":
+  version "7.0.16"
+  resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-7.0.16.tgz#19921d2fdc75d712ae1706330dba8ebec8ced52d"
+  integrity sha512-Bw/npxTVTeFPnQZmuczWRGRdxqJpWOOFZENx38ykyp42InwDFm4n72bfcCwmP/J4WqkPmMR4p+IracWruz/RUw==
+  dependencies:
+    "@semantic-release/error" "^2.1.0"
+    aggregate-error "^3.0.0"
+    debug "^4.0.0"
+    dir-glob "^3.0.0"
+    execa "^1.0.0"
+    fs-extra "^8.0.0"
+    globby "^10.0.0"
+    lodash "^4.17.4"
+    micromatch "^4.0.0"
+    p-reduce "^2.0.0"
+
 "@semantic-release/github@^5.1.0", "@semantic-release/github@^5.4.2":
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-5.4.2.tgz#1dbde876228c03ff9a000893a18aff5c6ab2cd61"


### PR DESCRIPTION
It looks like `@semantic-release/git` was not directly added by `semantic-release`, Oups 😇