### PR TITLE
Fix language override by default one (en) for all translation in app

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,8 +8,6 @@ import { i18nService } from '../i18n/I18nService';
 import './App.scss';
 
 export const App = () => {
-    i18nService.init();
-
     const selectedLanguage = useSelector(state => state.language.selectedLanguage);
 
     let component = <SelectLanguage />;

--- a/src/i18n/I18nService.test.ts
+++ b/src/i18n/I18nService.test.ts
@@ -7,7 +7,6 @@ describe(i18nService.constructor.name, () => {
 
     describe('when locale is set', () => {
         beforeEach(async () => {
-            await i18nService.init();
             await i18nService.setLanguage('fr');
         });
 

--- a/src/i18n/I18nService.ts
+++ b/src/i18n/I18nService.ts
@@ -5,10 +5,8 @@ import i18next from 'i18next';
 export type SupportedLocale = 'fr' | 'en';
 
 class I18nService {
-    constructor() {}
-
-    init() {
-        return i18next.init({
+    constructor() {
+        i18next.init({
             lng: 'en',
             fallbackLng: 'en',
             resources: {


### PR DESCRIPTION
Fix https://github.com/cycle-game/Cycle/issues/58.

Put i18next init in I18nService constructor instead of `init` function to avoid multiple calls to it as it was the case now.
As App.tsx is a FunctionComponent, it was called each time it should be renderer to reflect a data change, and so i18nService was re-init each time also.