### PR TITLE
Add Github Actions workflow to test, lint and build project

### DIFF
--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -14,9 +14,21 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile --silent
+        env:
+          HUSKY_SKIP_INSTALL: true
       - name: Build StoryBook
         run: |
-          yarn install
           yarn storybook:build --quiet
         env:
           CI: true

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -1,0 +1,22 @@
+name: Check StoryBook Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Build StoryBook
+        run: |
+          yarn install
+          yarn storybook:build --quiet
+        env:
+          CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           yarn install
           yarn lint:prettier
           yarn test
-          yarn storybook:build
           yarn build
         env:
           CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,21 +3,86 @@ name: Lint, Test & Build
 on: [push]
 
 jobs:
-  build:
-
+  lint:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
-      - name: Lint, Test & Build
-        run: |
-          yarn install
-          yarn lint:prettier
-          yarn test
-          yarn build
+          node-version: 12
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile --silent
         env:
-          CI: true
+          HUSKY_SKIP_INSTALL: true
+      - name: Lint
+        run: |
+          yarn lint:prettier
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile --silent
+        env:
+          HUSKY_SKIP_INSTALL: true
+      - name: Unit tests
+        run: |
+          yarn test
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile --silent
+        env:
+          HUSKY_SKIP_INSTALL: true
+      - name: Build
+        run: |
+          yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Lint, Test & Build
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Lint, Test & Build
+        run: |
+          yarn install
+          yarn lint:prettier
+          yarn test
+          yarn storybook:build
+          yarn build
+        env:
+          CI: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cycle
 
 [![Build Status](https://travis-ci.com/cycle-game/Cycle.svg?branch=master)](https://travis-ci.com/cycle-game/Cycle)
+![GitHub Build Status](https://github.com/cycle-game/Cycle/workflows/Lint%2C%20Test%20%26%20Build/badge.svg?branch=master)
 
 HTML5 game made with Phaser
 


### PR DESCRIPTION
Add GitHub actions to test, lint and build project just like we do on Travis for now.
All the above steps are done concurrently and cache `node_modules` so CI is faster than ever 🚅:
![image](https://user-images.githubusercontent.com/4112568/68891613-749d4300-0721-11ea-919a-22922094a84e.png)
