### PR TITLE
Improve PR CI with automatic deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Cycle
 
-[![Build Status](https://travis-ci.com/cycle-game/Cycle.svg?branch=master)](https://travis-ci.com/cycle-game/Cycle)
 ![GitHub Build Status](https://github.com/cycle-game/Cycle/workflows/Lint%2C%20Test%20%26%20Build/badge.svg?branch=master)
 
 HTML5 game made with Phaser

--- a/now.json
+++ b/now.json
@@ -1,0 +1,16 @@
+{
+    "name": "cycle-game",
+    "version": 2,
+    "builds": [
+        {
+            "src": "package.json",
+            "use": "@now/static-build",
+            "config": { "distDir": "dist" }
+        }
+    ],
+    "github": {
+        "autoJobCancelation": true,
+        "enabled": true,
+        "silent": false
+    }
+}


### PR DESCRIPTION
 - Remove reference to Travis build in README
 - Add automatic deployment of Cycle on Now, deployment are done for each PR (and destroyed when PR is merged) and are directly visible in the PR page:

![image](https://user-images.githubusercontent.com/4112568/71615971-3fa35d80-2bb4-11ea-9b19-13f9ade5ff50.png)


