### PR TITLE
Add NPM script to run UT with coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules
 
 dist
+
+coverage

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
         "start:dev": "webpack-dev-server --open --config webpack.dev.js",
         "storybook:start": "start-storybook -p 6006",
         "storybook:build": "build-storybook --quiet",
-        "test": "jest --forceExit --config jest.json"
+        "test": "jest --forceExit --config jest.json",
+        "test:cov": "jest --forceExit --config jest.json --ci --coverage"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
I tried to add code coverage in SonarCloud analysis but it's not done automatically for now and it looks to be a real pain to make it work.