### PR TITLE
chore: execute CI in pull requests too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Lint, Test & Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
Otherwise, PRs from forks (see for instance #218) won't execute checks.